### PR TITLE
Various asserts should not use Tensor ops

### DIFF
--- a/tensor.ts
+++ b/tensor.ts
@@ -4,12 +4,13 @@ import { expandShapeToKeepDim } from "./deeplearnjs/src/math/axis_util";
 import { NDArrayMath } from "./deeplearnjs/src/math/math";
 import { NDArrayMathCPU } from "./deeplearnjs/src/math/math_cpu";
 import { NDArrayMathGPU } from "./deeplearnjs/src/math/math_gpu";
-import { flatten, inferShape, RegularArray } from "./deeplearnjs/src/util";
+import { flatten, inferShape, RegularArray, TypedArray }
+  from "./deeplearnjs/src/util";
 import * as ops from "./ops";
 import { assert } from "./util";
 
 export type TensorLike = boolean | number | RegularArray<boolean> |
-  RegularArray<number> | NDArray | Tensor;
+  RegularArray<number> | TypedArray | Tensor;
 export type Shape = number[];
 
 const cpuMath: NDArrayMathCPU = new NDArrayMathCPU();
@@ -31,7 +32,7 @@ export class Tensor {
     }
   }
 
-  constructor(x: TensorLike) {
+  constructor(x: TensorLike | NDArray) {
     if (x instanceof Array) {
       // Argument is a JS array like [[1, 2], [3, 4]].
       const shape = inferShape(x);
@@ -60,6 +61,10 @@ export class Tensor {
 
     this.id = Tensor.nextId;
     Tensor.nextId++;
+  }
+
+  getValues(): TypedArray {
+    return this.ndarray.getValues();
   }
 
   // Lazily initialize.

--- a/tensor_test.ts
+++ b/tensor_test.ts
@@ -1,6 +1,6 @@
 import $ from "./propel";
-import { assert, assertFalse, assertShapesEqual, assertEqual, assertAllEqual }
-  from "./util";
+import { assert, assertFalse, assertShapesEqual, assertEqual, assertAllEqual,
+  assertAllClose } from "./util";
 
 function testShapes() {
   const a = $([[1, 2], [3, 4]]);
@@ -27,7 +27,7 @@ function testAllEqual() {
 
 function testLinspace() {
   const x = $.linspace(-4, 4, 6);
-  assertAllEqual(x, [-4., -2.4, -0.8,  0.8,  2.4, 4.]);
+  assertAllClose(x, [-4., -2.4, -0.8,  0.8,  2.4, 4.]);
 }
 
 function testMul() {


### PR DESCRIPTION
This is prep for running tests with the Tensorflow backend where we do
not want to rely on the nascent binding for testing.