### PR TITLE
Save for backward

### DIFF
--- a/backprop.ts
+++ b/backprop.ts
@@ -16,11 +16,7 @@ interface TapeEntry {
   oid: number;
   inputIds: number[];
   outputIds: number[];
-
-  // TODO These should not be set for, ops like exp or neg. Keeping references
-  // to all Tensors is very inefficient.
-  inputs: TensorLike[];
-  ans: ChainableTensor;
+  savedForBackward: any[];
 }
 
 // Hacky. How does one define methods on interfaces?
@@ -140,7 +136,7 @@ function imperativeGrad(target: ChainableTensor, sources: ChainableTensor[]):
     log("- outGrad %s", outGrad);
 
     const inGrads = getBackwardFuncs(op.name).map((bwFunc) => {
-      return bwFunc(outGrad, op.ans, ...op.inputs);
+      return bwFunc(outGrad, ...op.savedForBackward);
     });
 
     log("- inGrad %s", inGrads);

--- a/binding.cc
+++ b/binding.cc
@@ -293,7 +293,12 @@ static napi_value Execute(napi_env env, napi_callback_info info) {
     TensorWrap* tensor_wrap;
     napi_status =
         napi_unwrap(env, input, reinterpret_cast<void**>(&tensor_wrap));
-    check(napi_status == napi_ok);
+    if (napi_status != napi_ok) {
+      napi_throw_error(env, NULL, "Cannot unwrap Execute input");
+      TF_DeleteStatus(tf_status);
+      TFE_DeleteOp(op);
+      return NULL;
+    }
 
     TFE_OpAddInput(op, tensor_wrap->tf_tensor_handle, tf_status);
     check(TF_GetCode(tf_status) == TF_OK);

--- a/chainable_tensor.ts
+++ b/chainable_tensor.ts
@@ -9,6 +9,7 @@ export function convertChainable(t: types.TensorLike,
   if (t instanceof ChainableTensor) return t;
   return new ChainableTensor(convertBasic(t, dtype));
 }
+const $ = convertChainable;
 
 // ChainableTensor wraps a BasicTensor object. This is the main public
 // interface to tensor operatiors. Each instance has a unique id for use in
@@ -41,23 +42,23 @@ export class ChainableTensor implements types.BasicTensor {
   }
 
   add(x: types.TensorLike): ChainableTensor {
-    return ops.add(this, x);
+    return ops.add(this, $(x));
   }
 
   sub(x: types.TensorLike): ChainableTensor {
-    return ops.sub(this, x);
+    return ops.sub(this, $(x));
   }
 
   mul(x: types.TensorLike): ChainableTensor {
-    return ops.mul(this, x);
+    return ops.mul(this, $(x));
   }
 
   div(x: types.TensorLike): ChainableTensor {
-    return ops.div(this, x);
+    return ops.div(this, $(x));
   }
 
   matmul(x: types.TensorLike): ChainableTensor {
-    return ops.matmul(this, x);
+    return ops.matmul(this, $(x));
   }
 
   neg(): ChainableTensor {
@@ -82,7 +83,7 @@ export class ChainableTensor implements types.BasicTensor {
     if (perm === undefined) {
       perm = arange(this.rank).reverse();
     }
-    perm = convertChainable(perm, "int32");
+    perm = $(perm, "int32");
     return ops.transpose(this, perm);
   }
 
@@ -97,7 +98,7 @@ export class ChainableTensor implements types.BasicTensor {
       ta[i] = 1;
     }
 
-    const dimsT = convertChainable(ta, "bool");
+    const dimsT = $(ta, "bool");
     return ops.reverse(this, dimsT);
   }
 }

--- a/ops.ts
+++ b/ops.ts
@@ -6,18 +6,17 @@ import * as backprop from "./backprop";
 import { basicOps } from "./basic";
 import { ChainableTensor, convertChainable } from "./chainable_tensor";
 import { BasicTensor, TensorLike } from "./types";
+import { assert } from "./util";
 
-type FWFunc = (...args: BasicTensor[]) => BasicTensor;
-type BWFunc = (grad: ChainableTensor, ans: ChainableTensor, ...args:
-  TensorLike[]) => ChainableTensor;
-type OpFunc = (...args: TensorLike[]) => ChainableTensor;
+type FWFunc = (...args) => BasicTensor;
+type BWFunc = (grad: ChainableTensor, ...savedArgs) => ChainableTensor;
+type OpFunc = (...args) => ChainableTensor;
 
 let nextOpId = 1;
 
 interface OpInfo {
   name: string;
   opFunc: OpFunc;
-  fwFunc: FWFunc;
   bwFuncs: BWFunc[];
 }
 
@@ -25,123 +24,177 @@ const ops = {}; // name -> OpInfo
 
 // Define a forward op.
 function defFW(name: string, fwFunc: FWFunc): OpFunc {
-  const opFunc: OpFunc = (...args: TensorLike[]): ChainableTensor => {
-    const cargs = args.map((a) => convertChainable(a));
+  const opFunc: OpFunc = (...args): ChainableTensor => {
+    // We no longer automatically convert the op args to tensors.
+    // It's up to the caller.
+
+    const cTensors: ChainableTensor[] = [];
+
     // Gather ids of args that are tensors. null for non-Tensor args.
-    const inputIds = cargs.map((t) => t.id);
-    const bargs = cargs.map((t) => t.basic);
-    const basicAnswer = fwFunc(...bargs);
+    const inputIds = args.map((t) => {
+      if ((t as ChainableTensor).id) {
+        cTensors.push(t);
+        return (t as ChainableTensor).id;
+      } else {
+        return null;
+      }
+    });
+
+    // Convert any ChainableTensor args to basic ones.
+    const bargs = args.map((t) => {
+      if ((t as ChainableTensor).basic) {
+        return (t as ChainableTensor).basic;
+      } else {
+        return t;
+      }
+    });
+
+    // Call the forward function, and wrap the resulting BasicTensor in a
+    // ChainableTensor.
+    const basicAnswer: BasicTensor = fwFunc(...bargs);
     const ans = new ChainableTensor(basicAnswer);
+    cTensors.push(ans);
+
+    const savedForBackward =
+      convertSavedBasicsToChainables(globalSavedForBackward, cTensors);
+    globalSavedForBackward = null;
+
     backprop.recordOp({
-      ans,
       inputIds,
-      inputs: args,
       name,
       oid: nextOpId++,
       outputIds: [ans.id],
+      savedForBackward,
     });
     return ans;
   };
   ops[name] = {
     bwFuncs: null,
-    fwFunc,
     name,
     opFunc,
   };
   return opFunc;
 }
 
+function convertSavedBasicsToChainables(saved: any[], cTensors:
+                                        ChainableTensor[]) {
+  if (!saved) return null;
+  return saved.map((t) => {
+    if ((t as BasicTensor).getData) {
+      const b = t as BasicTensor;
+      for (const ct of cTensors) {
+        if (ct.basic === b) return ct;
+      }
+      throw new Error("Couldn't find corresponding ChainableTensor.");
+    } else {
+      // Not a tensor. Just pass it through.
+      return t;
+    }
+  });
+}
+
 function defBW(name: string, ...bwFuncs: Array<null | BWFunc>) {
   ops[name].bwFuncs = bwFuncs.map((f) => {
     if (f == null) {
-      return (g, ans, ...args) => ans.zerosLike();
+      return (g, ...args) => g.zerosLike();
     } else {
       return f;
     }
   });
 }
 
+let globalSavedForBackward = null;
+function saveForBackward(...args) {
+  // JavaScript is single threaded. Therefore we don't to worry about multiple
+  // call stacks.
+  assert(globalSavedForBackward === null);
+  globalSavedForBackward = args;
+}
+
 export function getBackwardFuncs(name: string): BWFunc[] {
   return ops[name].bwFuncs;
 }
 
-// TODO Identity for now.
-function broadcast(x, target) {
-  return x;
-}
-
-export let add = defFW("add", ( x, y) => basicOps.add(x, y));
+export const add = defFW("add", (x, y) => basicOps.add(x, y));
 defBW("add",
-  (g, ans, x, y) => broadcast(g, ans),
-  (g, ans, x, y) => broadcast(g, ans));
+  (g) => g,
+  (g) => g);
 
-export let sub = defFW("sub", (x, y) => basicOps.sub(x, y));
+export const sub = defFW("sub", (x, y) => basicOps.sub(x, y));
 defBW("sub",
-  (g, ans, x, y) => broadcast(g, ans),
-  (g, ans, x, y) => broadcast(neg(g), ans));
+  (g) => g,
+  (g) => neg(g));
 
-export let mul = defFW("mul", (x, y) => basicOps.mul(x, y));
+export const mul = defFW("mul", (x, y) => {
+  saveForBackward(x, y);
+  return basicOps.mul(x, y);
+});
 defBW("mul",
-  (g, ans, x, y) => mul(g, y),
-  (g, ans, x, y) => mul(g, x));
+  (g, x, y) => mul(g, y),
+  (g, x, y) => mul(g, x));
 
-export let div = defFW("div", (x, y) => basicOps.div(x, y));
+export const div = defFW("div", (x, y) => {
+  saveForBackward(x, y);
+  return basicOps.div(x, y);
+});
 defBW("div",
-  (g, ans, x, y) => div(g, y),
-  (g, ans, x, y) => div(neg(mul(g, x)), mul(y, y)));
+  (g, x, y) => div(g, y),
+  (g, x, y) => div(neg(mul(g, x)), mul(y, y)));
 
-// We create matmulT0 to mean the matmul op that transposes its first argument
-// and matmulT1 to mean the matmul op that transposes its second argument. This
-// is a hack to work around the fact that defFW can't handle optional/default
-// non-tensor parameters.
-// TODO combine matmulT0 and matmulT1 into matmul. This requires having
-// a mechanism for passthru arguments in defFW.
-export const matmulT0 = defFW("matmulT0", (x, y) => {
-  return basicOps.matmul(x, y, true, false);
-});
-
-export const matmulT1 = defFW("matmulT1", (x, y) => {
-  return basicOps.matmul(x, y, false, true);
-});
-
-export const matmul = defFW("matmul", (x, y) => {
-  return basicOps.matmul(x, y, false, false);
-});
-// y = x1 * x2
-// dx1 = dy * x2T
-// dx2 = x1T * dy
+export const matmul = defFW("matmul",
+  (a, b, transposeA = false, transposeB = false) => {
+    saveForBackward(a, b, transposeA, transposeB);
+    return basicOps.matmul(a, b, transposeA, transposeB);
+  });
+// y = a * b
+// da = dy * bT
+// db = aT * dy
 defBW("matmul",
-  (g, ans, x, y) => matmulT1(g, y),
-  (g, ans, x, y) => matmulT0(x, g));
+  (g, a, b, tA, tB) => matmul(g, b, tA, !tB),
+  (g, a, b, tA, tB) => matmul(a, g, !tA, tB));
 
-export let neg = defFW("neg", (x) => basicOps.neg(x));
-defBW("neg", (g, ans, x) => neg(g));
+export const neg = defFW("neg", (x) => basicOps.neg(x));
+defBW("neg", (g) => neg(g));
 
-export let exp = defFW("exp", (x) => basicOps.exp(x));
-defBW("exp", (g, ans, x) => mul(ans, g));
+export const exp = defFW("exp", (x) => {
+  const ans = basicOps.exp(x);
+  saveForBackward(ans);
+  return ans;
+});
+defBW("exp", (g, ans) => mul(ans, g));
 
-export let square = defFW("square", (x) => basicOps.square(x));
-defBW("square", (g, ans, x) => mul(g, mul(2, x)));
+export const square = defFW("square", (x) => {
+  saveForBackward(x);
+  return basicOps.square(x);
+});
+defBW("square", (g, x) => mul(g, mul(x, convertChainable(2, x.dtype))));
 
-export let sinh = defFW("sinh", (x) => basicOps.sinh(x));
-defBW("sinh", (g, ans, x) => mul(g, cosh(x)));
+export const sinh = defFW("sinh", (x) => {
+  saveForBackward(x);
+  return basicOps.sinh(x);
+});
+defBW("sinh", (g, x) => mul(g, cosh(x)));
 
-export let cosh = defFW("cosh", (x) => basicOps.cosh(x));
-defBW("cosh", (g, ans, x) => mul(g, sinh(x)));
+export let cosh = defFW("cosh", (x) => {
+  saveForBackward(x);
+  return basicOps.cosh(x);
+});
+defBW("cosh", (g, x) => mul(g, sinh(x)));
 
-export let tanh = defFW("tanh", (x) => basicOps.tanh(x));
-defBW("tanh", (g, ans, x) => div(g, square(cosh(x))));
+export let tanh = defFW("tanh", (x) => {
+  saveForBackward(x);
+  return basicOps.tanh(x);
+});
+defBW("tanh", (g, x) => div(g, square(cosh(x))));
 
 export let transpose = defFW("transpose", (x, perm) => {
+  saveForBackward(perm);
   return basicOps.transpose(x, perm);
 });
-defBW("transpose", (g, ans, x, perm) => {
-  return transpose(g, convertChainable(perm, "int32"));
-});
+defBW("transpose", (g, perm) => transpose(g, perm));
 
 export let reverse = defFW("reverse", (x, dims) => {
+  saveForBackward(dims);
   return basicOps.reverse(x, dims);
 });
-defBW("reverse", (g, ans, x, dims) => {
-  return reverse(g, dims);
-});
+defBW("reverse", (g, dims) => reverse(g, dims));


### PR DESCRIPTION
In order to remove the unnecessary matmulT0 and matmulT1, it's necessary
to pass the transposeA and tranposeB arguments thru to the backwards
pass.

Previously we were assuming that all arguments to ops were tensors. But
this isn't the case, there are many flags and other attributes that are
used in ops, which are not necessarally tensors... Like transposeA/B.
Or for reduction ops, the keep_dims.

Furthermore, we were always keeping references to all of the arguments
and outputs of every op during the forward pass, for potential use in
backwards passes. Different ops need different arguments remembered, so
this change introduces the saveForBackward() call. This should be more
memory efficent and simplify the current matmul situation.

PyTorch does something similiar
https://github.com/pytorch/pytorch/blob/5c809de4b4663c688ebc2cd389c2c866aa22f6e5/torch/autograd/function.py#L11