### PR TITLE
Remove TODOs on addGrad and mulDivGrad.

### DIFF
--- a/ops.ts
+++ b/ops.ts
@@ -135,8 +135,6 @@ export function getBackwardFuncs(name: string): BWFunc[] {
   return ops[name].bwFuncs;
 }
 
-// TODO This is called for each arg - unnecessary compute. Make it so defBW
-// just takes a single argument.
 function addGrad(firstArg: boolean) {
   return (g: ChainableTensor, sx: types.Shape, sy: types.Shape) => {
     // If sx and sy are the same (no broadcasting) just return g.
@@ -167,8 +165,6 @@ defBW("sub",
   (g, sx, sy) => addGrad(true)(g, sx, sy),
   (g, sx, sy) => addGrad(false)(g, sx, sy).neg());
 
-// TODO This is called for each arg - unnecessary compute. Make it so defBW
-// just takes a backwards function.
 function mulDivGrad(firstArg: boolean, isMul: boolean) {
   return (g: ChainableTensor, x: ChainableTensor, y: ChainableTensor) => {
     if (isMul) {


### PR DESCRIPTION
I'm not convinced that it's a good idea to do the backwards pass for all inputs
in a single function. It might be that backwards pass for certain inputs is not
needed, which will result in unnecessary computation. For example, in matmul,
the gradients for each input require a matmul.  If one of the gradients wasn't
needed, that would be an extra matmul. It's true that currently we always
compute all of the backwards passes - but this can be optimized - if we
continue having a different BW function for each input.