### PR TITLE
tf-binding: don't re-expand tensorflow_include_dir in gyp file

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
     {
       'target_name': 'tensorflow-binding',
       'sources': [ 'binding.cc' ],
-      'include_dirs': [ '<@(tensorflow_include_dir)' ],
+      'include_dirs': [ '<(tensorflow_include_dir)' ],
       'conditions': [
         ['OS=="win"', {
           'defines': [ 'COMPILER_MSVC' ],


### PR DESCRIPTION
This fixes the Windows build.