### PR TITLE
Add TensorOpts to specify dtype and device.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -16,12 +16,10 @@ import { assert, assertShapesEqual } from "./util";
  *
  * @arg t - An array of numbers, representing a Tensor. Or a Tensor in which
  *          case $() acts as the identity function.
- * @arg dtype - The data type of the returned tensor. For example "int32" or
- *              "float32".
- * @returns A Tensor object..
+ * @arg args - An object like this { dtype: "int32", device: "GPU:0" }
  */
-export function $(t: types.TensorLike, dtype?: types.DType): Tensor {
-  return convert(t, dtype);
+export function $(t: types.TensorLike, args?: types.TensorOpts): Tensor {
+  return convert(t, args);
 }
 
 /** Returns a list of available device names. EG ["CPU:0", "GPU:0", "GPU:1"].
@@ -92,14 +90,14 @@ export function fill(value: types.TensorLike, shape: types.Shape): Tensor {
 
 /** Return a new tensor of given shape and dtype, filled with zeros. */
 export function zeros(shape: types.Shape,
-                      dtype: types.DType = "float32"): Tensor {
-  return ops.zeros(shape, dtype);
+                      opts: types.TensorOpts = {dtype: "float32"}): Tensor {
+  return ops.zeros(shape, opts);
 }
 
 /** Return a new tensor of given shape and dtype, filled with ones. */
 export function ones(shape: types.Shape,
-                     dtype: types.DType = "float32"): Tensor {
-  return ops.ones(shape, dtype);
+                     opts: types.TensorOpts = {dtype: "float32"}): Tensor {
+  return ops.ones(shape, opts);
 }
 
 /** A collection of named Tensors. Used with OptimizerSGD.

--- a/backend.ts
+++ b/backend.ts
@@ -24,7 +24,9 @@ if (binding) {
 const create = tensorClass.fromTypedArray;
 
 export function convertBasic(x: types.TensorLike,
-    dtype?: types.DType, device?: string): types.BasicTensor {
+                             opts?: types.TensorOpts): types.BasicTensor {
+  const dtype = opts ? opts.dtype : undefined;
+  const device = (opts ? opts.device : null) || "CPU:0";
   if (typeof x === "number") {
     // TODO On TF we should take advantage of createSmallHandle for scalars.
     return create(types.makeTypedArray([x], dtype), [], dtype, device);

--- a/backprop.ts
+++ b/backprop.ts
@@ -198,7 +198,8 @@ function imperativeGrad(target: Tensor,
           // Null backwards function, return a zero tensor of the same shape and
           // dtype as the input.
           const shapeDType = op.inputShapeDTypes[i];
-          const zero = convert(0, shapeDType[1]);
+          const zero = convert(0,
+            {dtype: shapeDType[1], device: outGrad.device});
           return fill(zero, shapeDType[0]);
         }
       });

--- a/mnist.ts
+++ b/mnist.ts
@@ -81,7 +81,7 @@ async function loadFile(href, split: string, images: boolean) {
     assertEqual(littleEndianToBig(i32[i++]), 28);
   }
   const tensorData = new Int32Array(ui8.slice(4 * i));
-  const t = $(tensorData, "int32");
+  const t = $(tensorData, {dtype: "int32"});
   const shape = images ? [numExamples, 28, 28] : [numExamples];
   return t.reshape(shape);
 }

--- a/ops.ts
+++ b/ops.ts
@@ -134,12 +134,12 @@ export function getBackwardFuncs(name: string): BWFunc[] {
   return ops[name].bwFuncs;
 }
 
-export function ones(shape, dtype) {
-  return fill(convert(1, dtype), shape);
+export function ones(shape: types.Shape, opts: types.TensorOpts) {
+  return fill(convert(1, opts), shape);
 }
 
-export function zeros(shape, dtype) {
-  return fill(convert(0, dtype), shape);
+export function zeros(shape: types.Shape, opts: types.TensorOpts) {
+  return fill(convert(0, opts), shape);
 }
 
 function addGrad(firstArg: boolean) {
@@ -247,7 +247,10 @@ export const square = defFW("square", (x) => {
   saveForBackward(x);
   return bo.square(x);
 });
-defBW("square", (g, x) => mul(g, mul(x, convert(2, x.dtype))));
+defBW("square", (g, x) => {
+  const two = convert(2, x);
+  return mul(g, mul(x, two));
+});
 
 export const sinh = defFW("sinh", (x) => {
   saveForBackward(x);
@@ -348,7 +351,7 @@ defBW("reduceMean", (g, axes, shape, dtype) => {
     n *= shape[j];
     gs[j] = 1;
   }
-  const a = convert(1 / n, "float32");
+  const a = convert(1 / n, {dtype: "float32", device: g.device});
   return g.reshape(gs).mul(fill(a, shape));
 });
 

--- a/tensor.ts
+++ b/tensor.ts
@@ -5,9 +5,10 @@ import * as ops from "./ops";
 import * as types from "./types";
 import { allFinite, assert } from "./util";
 
-export function convert(t: types.TensorLike, dtype?: types.DType): Tensor {
+export function convert(t: types.TensorLike,
+                        opts?: types.TensorOpts): Tensor {
   if (t instanceof Tensor) return t;
-  return new Tensor(convertBasic(t, dtype));
+  return new Tensor(convertBasic(t, opts));
 }
 
 /** Tensor wraps a BasicTensor object. This is the main public
@@ -43,7 +44,7 @@ export class Tensor implements types.BasicTensor {
       // For now we stay silent.
       return new Tensor(bo.copyToDevice(t.basic, this.device));
     }
-    return new Tensor(convertBasic(t, dtype, this.device));
+    return new Tensor(convertBasic(t, {dtype, device: this.device}));
   }
 
   getData(): types.TypedArray {

--- a/tf.ts
+++ b/tf.ts
@@ -92,7 +92,7 @@ function dtypePropel2TF(dtype: types.DType): number {
     case "uint8":
       return binding.TF_UINT8;
     default:
-      throw new Error(`Not Implemented`);
+      throw new Error(`Not Implemented ${dtype}`);
   }
 }
 
@@ -116,7 +116,7 @@ export class TensorTF implements types.BasicTensor {
 
   static fromTypedArray(data: types.TypedArray, shape: types.Shape,
                         dtype?: types.DType, device?: string): TensorTF {
-    if (dtype === undefined) {
+    if (dtype == null) {
       dtype = types.getDType(data);
     }
     const dtypeTF = dtypePropel2TF(dtype);

--- a/types.ts
+++ b/types.ts
@@ -114,3 +114,12 @@ export function makeTypedArray(data, dtype: DType = "float32"): TypedArray {
       throw new Error("Not implemented");
   }
 }
+
+/** TensorOpts are used to build Tensors in functions like $() and zeros().
+ * Note that Tensors themselves implement the TensorOpts interface, so existing
+ * tensors can be used to construct similiarly typed and located tensors.
+ */
+export interface TensorOpts {
+  dtype: DType;
+  device?: string;
+}


### PR DESCRIPTION
Examples:

  $([1, 2, 3], {dtype: "float32"})

  $([1, 2, 3], {dtype: "int32", device: "GPU:0"})

  $([1, 2, 3], existingTensor)