### PR TITLE
src: export types that are used in signatures of exported functions

### DIFF
--- a/notebook.ts
+++ b/notebook.ts
@@ -66,12 +66,12 @@ const codemirrorOptions = {
   viewportMargin: Infinity,
 };
 
-interface Props {
+export interface Props {
   code: string;
   outputHTML: string;
   id: number;
 }
-interface State { outputHTML: string; }
+export interface State { outputHTML: string; }
 
 export class Cell extends Component<Props, State> {
   input: Element;
@@ -217,7 +217,7 @@ export class Cell extends Component<Props, State> {
   }
 }
 
-interface FixedProps {
+export interface FixedProps {
   code: string;
 }
 

--- a/test.ts
+++ b/test.ts
@@ -16,9 +16,9 @@
 import { inspect } from "util";
 import { assert, global, IS_NODE } from "./util";
 
-type TestFunction = () => void | Promise<void>;
+export type TestFunction = () => void | Promise<void>;
 
-interface TestDefinition {
+export interface TestDefinition {
   fn: TestFunction;
   name: string;
 }


### PR DESCRIPTION
This makes bare "tsc" work again.