### PR TITLE
Fixing DL/GPU tests

### DIFF
--- a/api_test.ts
+++ b/api_test.ts
@@ -918,7 +918,8 @@ test(async function api_cast() {
 
 test(async function api_oneHot() {
   for (const [device, $] of deviceTests()) {
-    const a = $([0, 1, 3, 4], {dtype: "uint8"});
+    // TODO dtype uint8
+    const a = $([0, 1, 3, 4], {dtype: "int32"});
     assertAllEqual(a.oneHot(6), [
       [1, 0, 0, 0, 0, 0],
       [0, 1, 0, 0, 0, 0],

--- a/tensor.ts
+++ b/tensor.ts
@@ -510,7 +510,7 @@ export class Tensor implements types.BasicTensor {
    */
   softmaxCE(labels: types.TensorLike): Tensor {
     const logits = this;
-    const labelsT = this.colocate(labels);
+    const labelsT = this.colocate(labels).cast("float32");
     assert(labelsT.rank === 2);
     assert(logits.rank === 2);
     const logQ = logits.logSoftmax();


### PR DESCRIPTION
This is a hack to control device placement inside of DL. There are several places where they rely on globally set NDArrayMath - this is incompatible with how we're using it.

For reference, this error manifest itself as as this:

    No data found for NDArray with data id 1. Use dl.ENV.math instead of
    constructing your own NDArrayMath. If you need to construct your own
    math, make sure this array is allocated after the math construction

We expect the hack introduced here to be cleaned up in future patches. 