### PR TITLE
Modify notebook output caching behavior.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ git:
   submodules_depth: 1
 node_js:
 - '8.8'
+install: echo "Intentionally skipping npm install."
 script:
 - npm rebuild puppeteer
 - ./tools/presubmit.js

--- a/tools/build_website.ts
+++ b/tools/build_website.ts
@@ -40,8 +40,8 @@ async function renderToHtmlWithJsdom(page: website.Page): Promise<string> {
   const p = new Promise<string>((resolve, reject) => {
     window.addEventListener("load", async() => {
       try {
-        while (website.serverSideExecuteQueue.length > 0) {
-          await website.serverSideExecuteQueue.shift();
+        while (website.notebookExecuteQueue.length > 0) {
+          await website.notebookExecuteQueue.shift();
         }
         const bodyHtml = document.body.innerHTML;
         const html =  website.getHTML(page.title, bodyHtml);

--- a/util.ts
+++ b/util.ts
@@ -240,3 +240,10 @@ export function inferShape(arr: number | boolean | RegularArray<number> |
   }
   return shape;
 }
+
+// Like setTimeout but with a promise.
+export function delay(t: number): Promise<void> {
+  return new Promise(function(resolve) {
+    setTimeout(resolve, t);
+  });
+}

--- a/website.ts
+++ b/website.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "fs";
 import { Component, h, render } from "preact";
 import * as nb from "./notebook";
 import { IS_WEB } from "./util";
-export { resetIds, serverSideExecuteQueue } from "./notebook";
+export { resetIds, notebookExecuteQueue } from "./notebook";
 
 export interface DocEntry {
   kind: "class" | "method" | "property";


### PR DESCRIPTION
Previously nb output was cached in a server-side render, and
used in the browser without re-executing the cell. Now output
is cached server side, but re-executed client side (only if the user has
JS enabled, obviously).

This is to remove the hack where innerHTML of output cells was
pulled during browser-side initial page render. This optimization
is complicating development.

This also re-enables the notebook-cell-updating feature.