### PR TITLE
Enable typeCheck in ts-node by default

### DIFF
--- a/tools/build_website.js
+++ b/tools/build_website.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// This file is just to easily run typescript from the command-line without
+// requiring that ts-node is installed. All of the logic for building the
+// website is in tools/build_website_impl.ts
+require("ts-node").register({"typeCheck": true });
+require("./build_website_impl.ts");

--- a/tools/build_website_impl.ts
+++ b/tools/build_website_impl.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env ts-node
 import * as fs from "fs";
 import { JSDOM } from "jsdom";
 import { join } from "path";

--- a/tools/run.js
+++ b/tools/run.js
@@ -3,6 +3,9 @@ const fs = require("fs");
 const { resolve } = require("path");
 const rimraf = require("rimraf");
 
+// Be extra careful to enable ts-node type checking.
+process.env.TS_NODE_TYPE_CHECK = true;
+
 // Always chdir to propel's project root.
 const root = resolve(__dirname, "..");
 process.chdir(root);
@@ -73,7 +76,7 @@ function symlink(a, b) {
 }
 
 function tsnode(args) {
-  sh("node ./node_modules/ts-node/dist/bin.js " + args);
+  sh("node ./node_modules/ts-node/dist/bin.js --type-check " + args);
 }
 
 const parcelCli = "./node_modules/parcel-bundler/bin/cli.js";

--- a/tools/test.js
+++ b/tools/test.js
@@ -4,7 +4,7 @@ const run = require("./run");
 // Build the project.
 run.sh("node ./tools/build_binding.js");
 run.sh("node ./tools/tsc.js");
-run.tsnode("./tools/build_website.ts");
+run.sh("node ./tools/build_website.js");
 run.parcel("test_dl.ts", "build/website", true);
 run.parcel("test_isomorphic.ts", "build/website", true);
 

--- a/tools/upload_website.js
+++ b/tools/upload_website.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const run = require("./run");
 const { execSync } = require("child_process");
-run.sh("node ./node_modules/ts-node/dist/bin.js tools/build_website.ts");
+run.sh("node ./tools/build_website.js");
 // pip install awscli
 execSync("aws s3 sync build/website/ s3://propelml.org --follow-symlinks --delete", {
   stdio: "inherit"


### PR DESCRIPTION
For unknown reasons ts-node 4.1.0 doesn't report typescript errors like previous versions did. For example the code
```javascript
if (5 === "5") console.log("what");
```
didn't trigger an error with ts-node 4.1.0 but does with 3.3.0. We don't particularly care about ts-node - so downgrading is the easiest fix.

This popped up while reviewing #203. Thanks Parsa.