### PR TITLE
Bump timeout for test_browser.

### DIFF
--- a/test_browser.ts
+++ b/test_browser.ts
@@ -38,7 +38,7 @@ const TESTS = [
   {
     doneMsg: /^DONE.*failed: 0/,
     href: "static/test.html#script=/test_isomorphic.js",
-    timeout: 30 * 1000
+    timeout: 40 * 1000
   },
 
   // These web pages are simply loaded; the test passes if no unhandled


### PR DESCRIPTION
We suspect there was a slow down in testNNExample introduced in
b5be8e75ee8a3e3bf97604ac8b95763e22f3d79f