### PR TITLE
Prevent unintentional cloning

### DIFF
--- a/website/notebook.ts
+++ b/website/notebook.ts
@@ -506,6 +506,7 @@ export interface NotebookProps {
 export interface NotebookState {
   doc?: db.NotebookDoc;
   errorMsg?: string;
+  isCloningInProgress: boolean;
 }
 
 // This defines the Notebook cells component.
@@ -515,6 +516,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     this.state = {
       doc: null,
       errorMsg: null,
+      isCloningInProgress: false,
     };
   }
 
@@ -559,8 +561,13 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   }
 
   async onClone() {
+    if (this.state.isCloningInProgress) {
+      return;
+    }
     console.log("Click clone");
+    this.setState({ isCloningInProgress: true });
     const clonedId = await db.active.clone(this.state.doc);
+    this.setState({ isCloningInProgress: false });
     // Redirect to new cloned notebook.
     window.location.href = nbUrl(clonedId);
   }


### PR DESCRIPTION
Imagine this scenario:
A user has a bad internet connection he/she clicks on the clone btn and expects to see sth, but nothing would happen and he/she clicks multiple times.
When he/she connects to the net all requests go one-by-one and that's what actually happened to me when using Notebook for the first time.