### PR TITLE
Make linear take scopeName argument.

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -1096,8 +1096,8 @@ test(async function api_sgd() {
 test(async function api_linear() {
   const params = api.params();
   const inputs = api.zeros([2, 5]);
-  const outputs = inputs.linear(params, 10);
-  assert(params.has("weights"));
-  assert(params.has("bias"));
+  const outputs = inputs.linear("L1", params, 10);
+  assert(params.has("L1/weights"));
+  assert(params.has("L1/bias"));
   assertShapesEqual(outputs.shape, [2, 10]);
 });


### PR DESCRIPTION
This forces scoping to happen, while still being explicit in parameter naming. It's also less characters than params.scope("...").