### PR TITLE
Move tensor utilities to tensor_util.ts

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -16,9 +16,10 @@ import { test } from "../tools/tester";
 import { fill, grad, linspace, listDevices, multigrad, ones,
   Params, randn, range, tensor, Tensor, TensorLike, zeros } from "./api";
 import * as api from "./api";
+import { assertAllClose, assertAllEqual, assertClose,
+  assertShapesEqual } from "./tensor_util";
 import * as types from "./types";
-import { assert, assertAllClose, assertAllEqual, assertClose,
-  assertShapesEqual, IS_NODE } from "./util";
+import { assert, IS_NODE } from "./util";
 
 function checkGrad(f, g, val = 1.0) {
   const epsilon = 0.01;

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -18,10 +18,11 @@
 // public API.
 
 import * as dl from "./dl";
+import { flatten, inferShape, isTypedArray, makeTypedArray }
+  from "./tensor_util";
 import * as tf from "./tf";
 import * as types from "./types";
-import { deepCloneArray, flatten, inferShape, IS_WEB, isTypedArray,
-  makeTypedArray } from "./util";
+import { deepCloneArray, IS_WEB } from "./util";
 
 // These globals will be set by onLoad
 export let tensorClass: any;

--- a/src/backend_test.ts
+++ b/src/backend_test.ts
@@ -14,7 +14,8 @@
  */
 import { test } from "../tools/tester";
 import { bo, convertBasic } from "./backend";
-import { assertAllClose, assertAllEqual, assertShapesEqual } from "./util";
+import { assertAllClose, assertAllEqual, assertShapesEqual }
+  from "./tensor_util";
 
 const tensor = convertBasic;
 

--- a/src/backprop.ts
+++ b/src/backprop.ts
@@ -20,7 +20,7 @@ import { fill, Params } from "./api";
 import { getBackwardFunc } from "./ops";
 import { convert, NamedTensors, Tensor } from "./tensor";
 import * as types from "./types";
-import { assert, assertEqual, CounterMap, log } from "./util";
+import { assert, CounterMap, log } from "./util";
 
 // Hacky. How does one define methods on interfaces?
 function tapeEntryToString(e: types.TapeEntry): string {
@@ -203,7 +203,7 @@ function imperativeGrad(target: Tensor,
     const op = oidLookup.get(oid);
 
     // TODO(scalar) Currently assuming ops have single output.
-    assertEqual(op.outputIds.length, 1);
+    assert(op.outputIds.length === 1);
     const outGrad = gradients.aggregate(op.outputIds[0]);
 
     log("backprop", tapeEntryToString(op));

--- a/src/binding_test.ts
+++ b/src/binding_test.ts
@@ -13,8 +13,8 @@
    limitations under the License.
  */
 import { test } from "../tools/tester";
+import { assert, assertAllEqual } from "./tensor_util";
 import * as tf from "./tf";
-import { assert, assertAllEqual } from "./util";
 
 assert(tf.loadBinding());
 const binding = tf.binding;

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -16,7 +16,7 @@ import { test } from "../tools/tester";
 import * as pr from "./api";
 import * as dataset from "./dataset";
 import { assert, assertAllClose, assertAllEqual, assertShapesEqual }
-  from "./util";
+  from "./tensor_util";
 
 test(async function dataset_datasetFromSlices() {
   const labels = pr.tensor([

--- a/src/disk_experiment_test.ts
+++ b/src/disk_experiment_test.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import * as rimraf from "rimraf";
 import { test } from "../tools/tester";
 import { DiskExperiment, isDir } from "./disk_experiment";
-import { assert, assertAllEqual } from "./util";
+import { assert, assertAllEqual } from "./tensor_util";
 
 function setup() {
   process.env.PROPEL_DIR = path.join(os.tmpdir(), "propel_test");

--- a/src/dl.ts
+++ b/src/dl.ts
@@ -26,8 +26,8 @@ import { NDArrayMath } from "./dl/math/math";
 import { Array1D, Array2D, Array3D, Array4D, NDArray, Scalar }
   from "./dl/math/ndarray";
 import { MatrixOrientation } from "./dl/math/types";
+import { assert, getDType, makeTypedArray } from "./tensor_util";
 import * as types from "./types";
-import { assert, getDType, makeTypedArray } from "./util";
 
 const deviceRegistry = new Map<string, NDArrayMath>();
 function lookupMath(device: string): NDArrayMath {

--- a/src/format.ts
+++ b/src/format.ts
@@ -13,8 +13,9 @@
    limitations under the License.
  */
 // This module is just to implement tensor.toString.
+import { getDType } from "./tensor_util";
 import * as types from "./types";
-import { getDType } from "./util";
+
 interface FormatOptions {
   precision: number;
   dtype: types.DType;

--- a/src/im_test.ts
+++ b/src/im_test.ts
@@ -15,8 +15,8 @@
 
 import { test } from "../tools/tester";
 import { imread } from "./im";
-import { assert, assertShapesEqual, fetch2ArgManipulation,
-  IS_NODE } from "./util";
+import { assert, assertShapesEqual } from "./tensor_util";
+import { fetch2ArgManipulation, IS_NODE } from "./util";
 
 // The tests use these files:
 // fa57d083e48e999ed3f210aefd92e5f7  testdata/sample.png

--- a/src/matmul_bench.ts
+++ b/src/matmul_bench.ts
@@ -13,7 +13,7 @@ for (let i = 0; i < 20; i++) {
   const start = end;
 
   for (let i = 0; i < count; i++) {
-    const t3 = t1.matmul(t2);
+    t1.matmul(t2);
   }
 
   end = Date.now() / 1000;

--- a/src/matplotlib.ts
+++ b/src/matplotlib.ts
@@ -14,7 +14,7 @@
  */
 import * as d3 from "d3";
 import { Tensor } from "./api";
-import { assertEqual } from "./util";
+import { assertEqual } from "./tensor_util";
 
 export interface OutputHandler {
   (): Element;

--- a/src/mnist.ts
+++ b/src/mnist.ts
@@ -13,7 +13,7 @@
    limitations under the License.
  */
 import { tensor, Tensor } from "./api";
-import { assertEqual, fetchArrayBuffer } from "./util";
+import { assert, fetchArrayBuffer } from "./util";
 
 export function filenames(split: string): [string, string] {
   if (split === "train") {
@@ -66,8 +66,8 @@ async function loadFile2(href: string) {
 
   let t;
   if (isImages) {
-    assertEqual(littleEndianToBig(i32[i++]), 28);
-    assertEqual(littleEndianToBig(i32[i++]), 28);
+    assert(littleEndianToBig(i32[i++]) === 28);
+    assert(littleEndianToBig(i32[i++]) === 28);
     const tensorData = new Int32Array(ui8.slice(4 * i));
     t = tensor(tensorData, {dtype: "int32"});
   } else {

--- a/src/mnist_test.ts
+++ b/src/mnist_test.ts
@@ -14,7 +14,7 @@
  */
 import { test } from "../tools/tester";
 import * as mnist from "./mnist";
-import { assertAllEqual, assertShapesEqual } from "./util";
+import { assertAllEqual, assertShapesEqual } from "./tensor_util";
 
 test(async function mnist_trainSplit() {
   const { images, labels } = await mnist.loadSplit("train");

--- a/src/npy_test.ts
+++ b/src/npy_test.ts
@@ -1,8 +1,9 @@
 import { test } from "../tools/tester";
 import * as pr from "./api";
 import * as npy from "./npy";
+import * as util from "./tensor_util";
 import * as types from "./types";
-import * as util from "./util";
+import { IS_NODE } from "./util";
 
 // Because the python interop test requires python and numpy installed
 // it is turned off by default here. The option is left for debugging
@@ -47,7 +48,7 @@ test(async function npy_serialize() {
   util.assertAllEqual(t, tt);
 });
 
-if (util.IS_NODE && testPython) {
+if (IS_NODE && testPython) {
   test(async function npy_pythonInterop() {
     await checkPython("[ 1.5  2.5]", [ 1.5, 2.5 ]);
     await checkPython("[ 1.  2.]", [ 1, 2 ]);

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -19,8 +19,8 @@
 import { bo } from "./backend";
 import * as backprop from "./backprop";
 import { convert, Tensor } from "./tensor";
+import { assert, bcastGradientArgs, shapesEqual } from "./tensor_util";
 import * as types from "./types";
-import { assert, bcastGradientArgs, shapesEqual } from "./util";
 
 // FWFunc defines a "primative" op (using autograd nomenclature). It should
 // never use Tensors, only BasicTensors. These forward pass functions

--- a/src/params_test.ts
+++ b/src/params_test.ts
@@ -1,7 +1,7 @@
 import { test } from "../tools/tester";
 import { randn, zeros } from "./api";
 import { params } from "./params";
-import { assert, assertAllEqual, assertShapesEqual } from "./util";
+import { assert, assertAllEqual, assertShapesEqual } from "./tensor_util";
 
 test(async function params_smoke() {
   const p = params();

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -17,8 +17,9 @@ import { bo, convertBasic } from "./backend";
 import * as format from "./format";
 import * as ops from "./ops";
 import { Params } from "./params";
+import { allFinite, assertShapesEqual } from "./tensor_util";
 import * as types from "./types";
-import { allFinite, assert, assertShapesEqual } from "./util";
+import { assert, IS_NODE } from "./util";
 
 export function convert(t: types.TensorLike,
                         opts?: types.TensorOpts): Tensor {
@@ -706,6 +707,18 @@ export class Tensor implements types.BasicTensor {
     }
     return t;
   }
+}
+
+if (IS_NODE) {
+  // This is currently node.js specific.
+  const s = require("util").inspect.custom;
+  Tensor.prototype[s] = function(depth: number, opts: {}) {
+    return this.toString();
+  };
+
+  process.on("unhandledRejection", (error) => {
+    throw error;
+  });
 }
 
 export type NamedTensors = { [name: string]: Tensor };

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -1,0 +1,211 @@
+/*!
+   Copyright 2018 Propel http://propel.site/.  All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+import { Tensor } from "./tensor";
+import { BasicTensor, DType, FlatVector, RegularArray, Shape, TensorLike,
+    TypedArray } from "./types";
+import { assert } from "./util";
+export { assert } from "./util";
+
+function toShapeAndFlatVector(t: TensorLike): [Shape, FlatVector] {
+  if ((t as Tensor).cpu) {
+    t = (t as Tensor).cpu(); // Copy to CPU if necessary.
+  }
+  if ((t as BasicTensor).dataSync) {
+    t = t as BasicTensor;
+    return [t.shape, t.dataSync()];
+  } else if (isTypedArray(t)) {
+    return [[t.length], t];
+  } else if (t instanceof Array) {
+    return [inferShape(t), flatten(t) as number[]];
+  } else if (typeof t === "number") {
+    return [[], [t]];
+  } else {
+    throw new Error("Not TensorLike");
+  }
+}
+
+function toNumber(t: TensorLike): number {
+  const values = toShapeAndFlatVector(t)[1];
+  if (values.length !== 1) {
+    throw new Error("Not Scalar");
+  }
+  return values[0];
+}
+
+export function shapesEqual(x: Shape, y: Shape): boolean {
+  if (x.length !== y.length) return false;
+  for (let i = 0; i < x.length; ++i) {
+    if (x[i] !== y[i]) return false;
+  }
+  return true;
+}
+
+export function allFinite(arr: number[]): boolean {
+  for (const n of arr) {
+    if (Number.isNaN(n)) return false;
+  }
+  return true;
+}
+
+export function assertClose(actual: TensorLike, expected: TensorLike,
+                            delta = 0.001) {
+  actual = toNumber(actual);
+  expected = toNumber(expected);
+  assert(Math.abs(actual - expected) < delta,
+    `actual: ${actual} expected: ${expected}`);
+}
+
+export function assertEqual(actual: TensorLike, expected: number | boolean,
+                            msg = null) {
+  actual = toNumber(actual);
+  if (!msg) { msg = `actual: ${actual} expected: ${expected}`; }
+  assert(actual === expected, msg);
+}
+
+export function assertShapesEqual(actual: Shape, expected: Shape) {
+  const J = JSON.stringify;
+  const msg = `Shape mismatch. actual: ${J(actual)} expected ${J(expected)}`;
+  assert(shapesEqual(actual, expected), msg);
+}
+
+export function assertAllEqual(actual: TensorLike, expected: TensorLike) {
+  const [actualShape, actualFlat] = toShapeAndFlatVector(actual);
+  const [expectedShape, expectedFlat] = toShapeAndFlatVector(expected);
+  assertShapesEqual(actualShape, expectedShape);
+  for (let i = 0; i < actualFlat.length; i++) {
+    assert(actualFlat[i] === expectedFlat[i],
+      `index ${i} actual: ${actualFlat[i]} expected: ${expectedFlat[i]}`);
+  }
+}
+
+export function assertAllClose(actual: TensorLike, expected: TensorLike,
+                               delta = 0.001) {
+  const [actualShape, actualFlat] = toShapeAndFlatVector(actual);
+  const [expectedShape, expectedFlat] = toShapeAndFlatVector(expected);
+
+  assertShapesEqual(actualShape, expectedShape);
+
+  for (let i = 0; i < actualFlat.length; ++i) {
+    const a = (actualFlat[i]) as number;
+    const e = (expectedFlat[i]) as number;
+    assert(Math.abs(a - e) < delta,
+      `index ${i} actual: ${actualFlat[i]} expected: ${expectedFlat[i]}`);
+  }
+}
+
+export function bcastGradientArgs(sx: Shape, sy: Shape): [Shape, Shape] {
+  const rx = [];
+  const ry = [];
+  const m = Math.max(sx.length, sy.length);
+  for (let i = 0; i < m; ++i) {
+    const argIndex = m - i - 1;
+    if (i >= sx.length) {
+      rx.unshift(argIndex);
+      continue;
+    }
+    if (i >= sy.length) {
+      ry.unshift(argIndex);
+      continue;
+    }
+
+    const xDim = sx[sx.length - i - 1];
+    const yDim = sy[sy.length - i - 1];
+
+    if (xDim === yDim) continue;
+
+    if (xDim === 1 && yDim !== 1) {
+      rx.unshift(argIndex);
+    } else if (xDim !== 1 && yDim === 1) {
+      ry.unshift(argIndex);
+    } else {
+      assert(xDim === 1 && yDim === 1, "Incompatible broadcast shapes.");
+    }
+  }
+  return [rx, ry];
+}
+
+export function isTypedArray(x: any): x is TypedArray {
+  return (x instanceof Float32Array || x instanceof Uint8Array ||
+          x instanceof Int32Array);
+}
+
+export function getDType(data: TypedArray): DType {
+  if (data instanceof Int32Array) {
+    return "int32";
+  } else if (data instanceof Float32Array) {
+    return "float32";
+  } else if (data instanceof Uint8Array) {
+    return "uint8";
+  } else {
+    throw new Error("Unsupported TypedArray flavor");
+  }
+}
+
+export function makeTypedArray(data, dtype: DType = "float32"): TypedArray {
+  switch (dtype) {
+    case "bool":
+      return new Uint8Array(data);
+    case "float32":
+      return new Float32Array(data);
+    case "int32":
+      return new Int32Array(data);
+    case "uint8":
+      return new Uint8Array(data);
+    default:
+      throw new Error("Not implemented");
+  }
+}
+
+/**
+ * flatten() and inferShape were forked from deps/deeplearnjs/src/util.ts
+ *
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export function flatten(
+    arr: number | boolean | RegularArray<number> | RegularArray<boolean>,
+    ret: Array<number | boolean> = []): Array<number | boolean> {
+  if (Array.isArray(arr)) {
+    for (let i = 0; i < arr.length; ++i) {
+      flatten(arr[i], ret);
+    }
+  } else {
+    ret.push(arr);
+  }
+  return ret;
+}
+
+export function inferShape(arr: number | boolean | RegularArray<number> |
+                           RegularArray<boolean>): number[] {
+  const shape: number[] = [];
+  while (arr instanceof Array) {
+    shape.push(arr.length);
+    arr = arr[0];
+  }
+  return shape;
+}

--- a/src/tensor_util_test.ts
+++ b/src/tensor_util_test.ts
@@ -1,0 +1,58 @@
+/*!
+   Copyright 2018 Propel http://propel.site/.  All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+import { test } from "../tools/tester";
+import { assertShapesEqual, bcastGradientArgs } from "./tensor_util";
+
+test(async function tensor_util_bcastGradientArgs() {
+  let [r0, r1] = bcastGradientArgs([2, 3, 5], [1]);
+  assertShapesEqual(r0, []);
+  assertShapesEqual(r1, [0, 1, 2]);
+
+  [r0, r1] = bcastGradientArgs([1], [2, 3, 5]);
+  assertShapesEqual(r0, [0, 1, 2]);
+  assertShapesEqual(r1, []);
+
+  [r0, r1] = bcastGradientArgs([2, 3, 5], [5]);
+  assertShapesEqual(r0, []);
+  assertShapesEqual(r1, [0, 1]);
+
+  [r0, r1] = bcastGradientArgs([5], [2, 3, 5]);
+  assertShapesEqual(r0, [0, 1]);
+  assertShapesEqual(r1, []);
+
+  [r0, r1] = bcastGradientArgs([2, 3, 5], [3, 5]);
+  assertShapesEqual(r0, []);
+  assertShapesEqual(r1, [0]);
+
+  [r0, r1] = bcastGradientArgs([3, 5], [2, 3, 5]);
+  assertShapesEqual(r0, [0]);
+  assertShapesEqual(r1, []);
+
+  [r0, r1] = bcastGradientArgs([2, 3, 5], [3, 1]);
+  assertShapesEqual(r0, []);
+  assertShapesEqual(r1, [0, 2]);
+
+  [r0, r1] = bcastGradientArgs([3, 1], [2, 3, 5]);
+  assertShapesEqual(r0, [0, 2]);
+  assertShapesEqual(r1, []);
+
+  [r0, r1] = bcastGradientArgs([2, 1, 5], [3, 1]);
+  assertShapesEqual(r0, [1]);
+  assertShapesEqual(r1, [0, 2]);
+
+  [r0, r1] = bcastGradientArgs([3, 1], [2, 1, 5]);
+  assertShapesEqual(r0, [0, 2]);
+  assertShapesEqual(r1, [1]);
+});

--- a/src/tf.ts
+++ b/src/tf.ts
@@ -14,8 +14,8 @@
  */
 // TensorFlow backend.
 import { Handle } from "./binding";
+import { assert, assertEqual, getDType } from "./tensor_util";
 import * as types from "./types";
-import { assert, assertEqual, getDType } from "./util";
 
 export let binding;
 export let ctx;

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,62 +12,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-import { Tensor } from "./tensor";
-import { BasicTensor, DType, FlatVector, RegularArray, Shape,
-  TensorLike, TypedArray } from "./types";
+import { RegularArray } from "./types";
 
 const debug = false;
-const J = JSON.stringify;
 const globalEval = eval;
 export const IS_WEB = typeof window !== "undefined";
 export const IS_NODE = !IS_WEB;
 export const global = globalEval(IS_WEB ? "window" : "global");
-
-if (IS_NODE) {
-  // This is currently node.js specific.
-  // TODO: move to api.js once it can be shared with the browser.
-  const s = require("util").inspect.custom;
-  Tensor.prototype[s] = function(depth: number, opts: {}) {
-    return this.toString();
-  };
-
-  process.on("unhandledRejection", (error) => {
-    throw error;
-  });
-}
-
-export function allFinite(arr: number[]): boolean {
-  for (const n of arr) {
-    if (Number.isNaN(n)) return false;
-  }
-  return true;
-}
-
-function toShapeAndFlatVector(t: TensorLike): [Shape, FlatVector] {
-  if ((t as Tensor).cpu) {
-    t = (t as Tensor).cpu(); // Copy to CPU if necessary.
-  }
-  if ((t as BasicTensor).dataSync) {
-    t = t as BasicTensor;
-    return [t.shape, t.dataSync()];
-  } else if (isTypedArray(t)) {
-    return [[t.length], t];
-  } else if (t instanceof Array) {
-    return [inferShape(t), flatten(t) as number[]];
-  } else if (typeof t === "number") {
-    return [[], [t]];
-  } else {
-    throw new Error("Not TensorLike");
-  }
-}
-
-function toNumber(t: TensorLike): number {
-  const values = toShapeAndFlatVector(t)[1];
-  if (values.length !== 1) {
-    throw new Error("Not Scalar");
-  }
-  return values[0];
-}
 
 export function log(...args: any[]) {
   if (debug) {
@@ -75,63 +26,9 @@ export function log(...args: any[]) {
   }
 }
 
-export function shapesEqual(x: Shape, y: Shape): boolean {
-  if (x.length !== y.length) return false;
-  for (let i = 0; i < x.length; ++i) {
-    if (x[i] !== y[i]) return false;
-  }
-  return true;
-}
-
 export function assert(expr: boolean, msg = "") {
   if (!expr) {
     throw new Error(msg);
-  }
-}
-
-
-export function assertClose(actual: TensorLike, expected: TensorLike,
-                            delta = 0.001) {
-  actual = toNumber(actual);
-  expected = toNumber(expected);
-  assert(Math.abs(actual - expected) < delta,
-    `actual: ${actual} expected: ${expected}`);
-}
-
-export function assertEqual(actual: TensorLike, expected: number | boolean,
-                            msg = null) {
-  actual = toNumber(actual);
-  if (!msg) { msg = `actual: ${actual} expected: ${expected}`; }
-  assert(actual === expected, msg);
-}
-
-export function assertShapesEqual(actual: Shape, expected: Shape) {
-  const msg = `Shape mismatch. actual: ${J(actual)} expected ${J(expected)}`;
-  assert(shapesEqual(actual, expected), msg);
-}
-
-export function assertAllEqual(actual: TensorLike, expected: TensorLike) {
-  const [actualShape, actualFlat] = toShapeAndFlatVector(actual);
-  const [expectedShape, expectedFlat] = toShapeAndFlatVector(expected);
-  assertShapesEqual(actualShape, expectedShape);
-  for (let i = 0; i < actualFlat.length; i++) {
-    assert(actualFlat[i] === expectedFlat[i],
-      `index ${i} actual: ${actualFlat[i]} expected: ${expectedFlat[i]}`);
-  }
-}
-
-export function assertAllClose(actual: TensorLike, expected: TensorLike,
-                               delta = 0.001) {
-  const [actualShape, actualFlat] = toShapeAndFlatVector(actual);
-  const [expectedShape, expectedFlat] = toShapeAndFlatVector(expected);
-
-  assertShapesEqual(actualShape, expectedShape);
-
-  for (let i = 0; i < actualFlat.length; ++i) {
-    const a = (actualFlat[i]) as number;
-    const e = (expectedFlat[i]) as number;
-    assert(Math.abs(a - e) < delta,
-      `index ${i} actual: ${actualFlat[i]} expected: ${expectedFlat[i]}`);
   }
 }
 
@@ -166,78 +63,6 @@ export function deepCloneArray(arr: RegularArray<any>): typeof arr {
   return arr2;
 }
 
-export function bcastGradientArgs(sx: Shape, sy: Shape): [Shape, Shape] {
-  const rx = [];
-  const ry = [];
-  const m = Math.max(sx.length, sy.length);
-  for (let i = 0; i < m; ++i) {
-    const argIndex = m - i - 1;
-    if (i >= sx.length) {
-      rx.unshift(argIndex);
-      continue;
-    }
-    if (i >= sy.length) {
-      ry.unshift(argIndex);
-      continue;
-    }
-
-    const xDim = sx[sx.length - i - 1];
-    const yDim = sy[sy.length - i - 1];
-
-    if (xDim === yDim) continue;
-
-    if (xDim === 1 && yDim !== 1) {
-      rx.unshift(argIndex);
-    } else if (xDim !== 1 && yDim === 1) {
-      ry.unshift(argIndex);
-    } else {
-      assert(xDim === 1 && yDim === 1, "Incompatible broadcast shapes.");
-    }
-  }
-  return [rx, ry];
-}
-
-/**
- * flatten() and inferShape were forked from deps/deeplearnjs/src/util.ts
- *
- * Copyright 2017 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * =============================================================================
- */
-
-export function flatten(
-    arr: number | boolean | RegularArray<number> | RegularArray<boolean>,
-    ret: Array<number | boolean> = []): Array<number | boolean> {
-  if (Array.isArray(arr)) {
-    for (let i = 0; i < arr.length; ++i) {
-      flatten(arr[i], ret);
-    }
-  } else {
-    ret.push(arr);
-  }
-  return ret;
-}
-
-export function inferShape(arr: number | boolean | RegularArray<number> |
-                           RegularArray<boolean>): number[] {
-  const shape: number[] = [];
-  while (arr instanceof Array) {
-    shape.push(arr.length);
-    arr = arr[0];
-  }
-  return shape;
-}
-
 // Like setTimeout but with a promise.
 export function delay(t: number): Promise<void> {
   return new Promise(function(resolve) {
@@ -256,38 +81,6 @@ export function objectsEqual(a, b) {
     }
   }
   return true;
-}
-
-export function isTypedArray(x: any): x is TypedArray {
-  return (x instanceof Float32Array || x instanceof Uint8Array ||
-          x instanceof Int32Array);
-}
-
-export function getDType(data: TypedArray): DType {
-  if (data instanceof Int32Array) {
-    return "int32";
-  } else if (data instanceof Float32Array) {
-    return "float32";
-  } else if (data instanceof Uint8Array) {
-    return "uint8";
-  } else {
-    throw new Error("Unsupported TypedArray flavor");
-  }
-}
-
-export function makeTypedArray(data, dtype: DType = "float32"): TypedArray {
-  switch (dtype) {
-    case "bool":
-      return new Uint8Array(data);
-    case "float32":
-      return new Float32Array(data);
-    case "int32":
-      return new Int32Array(data);
-    case "uint8":
-      return new Uint8Array(data);
-    default:
-      throw new Error("Not implemented");
-  }
 }
 
 const propelHosts = new Set(["127.0.0.1", "localhost", "propelml.org"]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,9 +89,6 @@ export function assert(expr: boolean, msg = "") {
   }
 }
 
-export function assertFalse(expr: boolean, msg = "") {
-  assert(!expr, msg);
-}
 
 export function assertClose(actual: TensorLike, expected: TensorLike,
                             delta = 0.001) {

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -12,23 +12,24 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
+
 import { test } from "../tools/tester";
+import { assert } from "./util";
 import * as util from "./util";
-import { assert, assertEqual, assertShapesEqual } from "./util";
 
 test(async function util_counterMap() {
   const m = new util.CounterMap();
-  assertEqual(m.get(0), 0);
+  assert(m.get(0) === 0);
   m.inc(0);
   m.inc(0);
-  assertEqual(m.get(0), 2);
-  assertEqual(m.get(1), 0);
+  assert(m.get(0) === 2);
+  assert(m.get(1) === 0);
   m.inc(1);
-  assertEqual(m.get(1), 1);
+  assert(m.get(1) === 1);
   m.dec(0);
   m.inc(1);
-  assertEqual(m.get(0), 1);
-  assertEqual(m.get(1), 2);
+  assert(m.get(0) === 1);
+  assert(m.get(1) === 2);
   const k = m.keys();
   console.log(k);
 });
@@ -45,46 +46,4 @@ test(async function util_deepCloneArray() {
   assert(arr1[1][0] === arr2[1][0]);
   assert(arr1[0][1] === arr2[0][1]);
   assert(arr1[1][1] === arr2[1][1]);
-});
-
-test(async function util_bcastGradientArgs() {
-  let [r0, r1] = util.bcastGradientArgs([2, 3, 5], [1]);
-  assertShapesEqual(r0, []);
-  assertShapesEqual(r1, [0, 1, 2]);
-
-  [r0, r1] = util.bcastGradientArgs([1], [2, 3, 5]);
-  assertShapesEqual(r0, [0, 1, 2]);
-  assertShapesEqual(r1, []);
-
-  [r0, r1] = util.bcastGradientArgs([2, 3, 5], [5]);
-  assertShapesEqual(r0, []);
-  assertShapesEqual(r1, [0, 1]);
-
-  [r0, r1] = util.bcastGradientArgs([5], [2, 3, 5]);
-  assertShapesEqual(r0, [0, 1]);
-  assertShapesEqual(r1, []);
-
-  [r0, r1] = util.bcastGradientArgs([2, 3, 5], [3, 5]);
-  assertShapesEqual(r0, []);
-  assertShapesEqual(r1, [0]);
-
-  [r0, r1] = util.bcastGradientArgs([3, 5], [2, 3, 5]);
-  assertShapesEqual(r0, [0]);
-  assertShapesEqual(r1, []);
-
-  [r0, r1] = util.bcastGradientArgs([2, 3, 5], [3, 1]);
-  assertShapesEqual(r0, []);
-  assertShapesEqual(r1, [0, 2]);
-
-  [r0, r1] = util.bcastGradientArgs([3, 1], [2, 3, 5]);
-  assertShapesEqual(r0, [0, 2]);
-  assertShapesEqual(r1, []);
-
-  [r0, r1] = util.bcastGradientArgs([2, 1, 5], [3, 1]);
-  assertShapesEqual(r0, [1]);
-  assertShapesEqual(r1, [0, 2]);
-
-  [r0, r1] = util.bcastGradientArgs([3, 1], [2, 1, 5]);
-  assertShapesEqual(r0, [0, 2]);
-  assertShapesEqual(r1, [1]);
 });

--- a/tools/presubmit.js
+++ b/tools/presubmit.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const run = require("./run");
 run.rmrf("./build");
+run.sh("node ./tools/tsc.js --noEmit");
 run.sh("node ./tools/cpplint.js");
 run.sh("node ./tools/tslint.js");
 run.sh("node ./tools/stylelint.js");

--- a/tools/test_isomorphic.ts
+++ b/tools/test_isomorphic.ts
@@ -7,4 +7,5 @@ import "../src/mnist_test";
 import "../src/nn_example_test";
 import "../src/npy_test";
 import "../src/params_test";
+import "../src/tensor_util_test";
 import "../src/util_test";

--- a/tools/test_node.ts
+++ b/tools/test_node.ts
@@ -1,5 +1,6 @@
-import "../src/disk_experiment_test";
 import "./test_isomorphic";
+
+import "../src/disk_experiment_test";
 
 // Only on Node/TF should we run the binding_test.
 import { backend } from "../src/api";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "sourceMap": true,
     "target": "es2017"
   },
-  "exclude": ["build", "deps", "node_modules", "gendoc"]
+  "exclude": ["build", "deps", "node_modules"]
 }
 

--- a/tsconfig_local.json
+++ b/tsconfig_local.json
@@ -4,11 +4,5 @@
     "allowJs": true,
     "declaration": false,
     "outDir": "build/"
-  },
-  "include": [
-    "src/load_binding.js",
-    "src/api.ts",
-    "src/*_test.ts",
-    "tools/test_*.ts"
-  ]
+  }
 }

--- a/website/notebook_test.ts
+++ b/website/notebook_test.ts
@@ -1,4 +1,4 @@
-import { h, render, rerender } from "preact";
+import { h, render } from "preact";
 import { assert, objectsEqual } from "../src/util";
 import { testBrowser } from "../tools/tester";
 import { enableMock } from "./db";
@@ -62,7 +62,9 @@ testBrowser(async function notebook_focusNextCell() {
   const cellEls = document.getElementsByClassName("notebook-cell");
   assert(cellEls.length >= 2);
   const first = nb.lookupCell(cellEls[0].id);
+  assert(first != null);
   const second = nb.lookupCell(cellEls[1].id);
+  assert(second != null);
 
   first.focus();
 

--- a/website/website_main.ts
+++ b/website/website_main.ts
@@ -1,5 +1,5 @@
 import { h, render, rerender } from "preact";
-import { assert, delay, IS_WEB } from "../src/util";
+import { assert, IS_WEB } from "../src/util";
 import { enableFirebase } from "./db";
 import { drainExecuteQueue } from "./notebook";
 import { Router } from "./website";


### PR DESCRIPTION
This is in preparation for landing the sandboxed notebook.
Starting with that there will be two bundles, one that runs inside the sandbox (which contains propel), and one for the website (containing preact).
Since util.ts is used in both, we have to make sure to not pull each other.