### PR TITLE
Parcel upgrade to 1.6.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["transform-runtime",
+      {
+        "polyfill": false,
+        "regenerator": true
+      }]
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "plugins": [
-    ["transform-runtime",
-      {
-        "polyfill": false,
-        "regenerator": true
-      }]
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@types/node": "^8.9.4",
     "@types/seedrandom": "^2.4.27",
     "acorn": "^5.5.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-runtime": "^6.26.0",
     "codemirror": "^5.35.0",
     "d3": "^4.13.0",
     "http-server": "^0.10.0",
@@ -42,5 +44,6 @@
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "yauzl": "^2.9.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jpeg-js": "^0.3.3",
     "jsdom": "^11.6.2",
     "node-fetch": "^1.7.3",
-    "parcel-bundler": "1.5.1",
+    "parcel-bundler": "^1.6.2",
     "pngjs": "^3.2.2",
     "preact": "^8.2.7",
     "puppeteer": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,5 @@
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "yauzl": "^2.9.1"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@types/node": "^8.9.4",
     "@types/seedrandom": "^2.4.27",
     "acorn": "^5.5.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-runtime": "^6.26.0",
     "codemirror": "^5.35.0",
     "d3": "^4.13.0",
     "http-server": "^0.10.0",
@@ -44,5 +42,8 @@
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "yauzl": "^2.9.1"
-  }
+  },
+  "browserslist": [
+    ">5%"
+  ]
 }


### PR DESCRIPTION
Fixes #264
In Parcel 1.6x, there were some changes made where `async` functions are transformed to `regeneratorRuntime`, which is `undefined`. Used this issue to find a resolution: https://github.com/parcel-bundler/parcel/issues/871