### PR TITLE
tf: reduceMean should always return float32.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -168,3 +168,18 @@ export function ones(shape: types.Shape,
   }
   return ops.ones(shape, opts);
 }
+
+/** Constructs a uint8 tensor. */
+export function uint8(t: types.TensorLike): Tensor {
+  return tensor(t, { dtype: "uint8" });
+}
+
+/** Constructs a int32 tensor. */
+export function int32(t: types.TensorLike): Tensor {
+  return tensor(t, { dtype: "int32" });
+}
+
+/** Constructs a float32 tensor. */
+export function float32(t: types.TensorLike): Tensor {
+  return tensor(t, { dtype: "float32" });
+}

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -474,6 +474,7 @@ testDevices(async function api_reduceMean(tensor, device) {
     [t, t, t],
     [t, t, t],
   ]);
+  assertAllEqual(api.uint8([255, 255, 255]).reduceMean(), 255);
 });
 
 testDevices(async function api_reduceMax(tensor, device) {

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -1149,3 +1149,15 @@ test(async function api_data() {
   assertAllEqual(await t.data(), [0, 1, 2]);
   assertAllEqual(t.dataSync(), [0, 1, 2]);
 });
+
+test(async function api_dtypeConstructors() {
+  const ui8 = api.uint8([254, 255, 256, 257]);
+  assert(ui8.dtype === "uint8");
+  assertAllEqual(ui8, [254, 255, 0, 1]);
+  const i32 = api.int32([1, 2, 3]);
+  assert(i32.dtype === "int32");
+  assertAllEqual(i32, [1, 2, 3]);
+  const f32 = api.float32([1.5, 3.5]);
+  assert(f32.dtype === "float32");
+  assertAllEqual(f32, [1.5, 3.5]);
+});

--- a/src/tf.ts
+++ b/src/tf.ts
@@ -353,6 +353,11 @@ export class OpsTF implements types.BackendOps {
 
   reduceMean(x: TensorTF, axes: number[], keepDims: boolean): TensorTF
   {
+    // reduceMean should always return float32 tensor but TF doesn't
+    // handled that conversion.
+    if (x.dtype !== "float32") {
+      x = this.cast(x, "float32");
+    }
     // axesT is expected to be on CPU.
     const axesT = int32Small(axes);
     return execute0("Mean", [x, axesT], [


### PR DESCRIPTION
cc @qti3e 

```
> python
Python 2.7.14 (default, Sep 25 2017, 09:53:22)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> np.uint8([255, 255, 255]).mean()
255.0
```