### PR TITLE
ci: disable OS X builds because of Travis CI downtime/backlog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 language: node_js
 os:
 - linux
-- osx
+# - osx -- disabled because of Travis CI downtime/backlog
 git:
   submodules_depth: 1
 node_js:


### PR DESCRIPTION
Fixes #372