### PR TITLE
Set node version to v8.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Required for building tensorflow-binding, since with lower node version
(< v8.6.0) gives: `error: use of undeclared identifier 'NAPI_AUTO_LENGTH'`.