### PR TITLE
notebook: various output handler improvements

### DIFF
--- a/src/matplotlib.ts
+++ b/src/matplotlib.ts
@@ -26,6 +26,15 @@ export function setOutputHandler(h: OutputHandler) {
   currentOutputHandler = h;
 }
 
+export function imshow(tensor: Tensor): void {
+  if (!currentOutputHandler) {
+    console.warn("imshow: no output handler");
+    return;
+  }
+  const image = toUint8Image(tensor);
+  currentOutputHandler.imshow(image);
+}
+
 export function plot(...args) {
   if (!currentOutputHandler) {
     console.warn("plot: no output handler");
@@ -65,13 +74,4 @@ export function plot(...args) {
   }
 
   currentOutputHandler.plot(data);
-}
-
-export function imshow(tensor: Tensor): void {
-  if (!currentOutputHandler) {
-    console.warn("imshow: no output handler");
-    return;
-  }
-  const image = toUint8Image(tensor);
-  currentOutputHandler.imshow(image);
 }

--- a/src/output_handler.ts
+++ b/src/output_handler.ts
@@ -20,8 +20,9 @@ import { createCanvas, Image } from "./im";
 export type PlotData = Array<Array<{ x: number, y: number }>>;
 
 export interface OutputHandler {
-  plot(data: PlotData): void;
   imshow(image: Image): void;
+  plot(data: PlotData): void;
+  print(text: string): void;
 }
 
 export class OutputHandlerDOM implements OutputHandler {
@@ -83,6 +84,11 @@ export class OutputHandlerDOM implements OutputHandler {
     return [xMin, xMax, yMin, yMax];
   }
 
+  imshow(image: Image): void {
+    const canvas = createCanvas(image);
+    this.element.appendChild(canvas);
+  }
+
   plot(data: PlotData): void {
     const outputId_ = "#" + this.element.id;
 
@@ -136,8 +142,12 @@ export class OutputHandlerDOM implements OutputHandler {
       });
   }
 
-  imshow(image: Image): void {
-    const canvas = createCanvas(image);
-    this.element.appendChild(canvas);
+  print(text: string): void {
+    const element = this.element;
+    const last = element.lastChild;
+    let s = (last && last.nodeType !== Node.TEXT_NODE) ? "\n" : "";
+    s += text + "\n";
+    const el = document.createTextNode(s);
+    element.appendChild(el);
   }
 }

--- a/website/sandbox.ts
+++ b/website/sandbox.ts
@@ -54,7 +54,7 @@ async function runCell(source: string, cellId: number): Promise<void> {
     }
   } catch (e) {
     const message = transpiler.formatException(e);
-    rpc.call("console", cellId, message);
+    rpc.call("print", cellId, message);
     // When running tests, rethrow any errors. This ensures that errors
     // occurring during notebook cell evaluation result in test failure.
     if (window.navigator.webdriver) {
@@ -87,30 +87,34 @@ class Console {
     return value + ""; // Convert to string.
   }
 
-  private send(...args) {
-    return this.rpc.call("console", this.cellId, ...args.map(this.inspect));
+  private print(...args: any[]) {
+    this.rpc.call("print", this.cellId, args.map(this.inspect).join(" "));
   }
 
-  log(...args) {
-    return this.send(...args);
+  log(...args: any[]): void {
+    this.print(...args);
   }
 
-  warn(...args) {
-    return this.send(...args);
+  warn(...args: any[]): void {
+    this.print(...args);
   }
 
-  error(...args) {
-    return this.send(...args);
+  error(...args: any[]): void {
+    this.print(...args);
   }
 }
 
 matplotlib.setOutputHandler({
+  imshow(data: any): void {
+    rpc.call("imshow", guessCellId(), data);
+  },
+
   plot(data: any): void {
     rpc.call("plot", guessCellId(), data);
   },
 
-  imshow(data: any): void {
-    rpc.call("imshow", guessCellId(), data);
+  print(data: any): void {
+    rpc.call("print", guessCellId(), data);
   }
 });
 
@@ -123,7 +127,7 @@ window.addEventListener("error", (ev: ErrorEvent) => {
     cellId = guessCellId();
     message = ev.message;
   }
-  rpc.call("console", cellId, message);
+  rpc.call("print", cellId, message);
 });
 
 // TODO: also handle unhandledrejection. This should work in theory, in Chrome


### PR DESCRIPTION
* Use one output handler per cell, not one per output.
* Make the output handler responsible creating DOM text nodes.
* Rename 'console' RPC call to 'print()'.