### PR TITLE
Implement reduceMin

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -503,6 +503,18 @@ testDevices(async function api_reduceMax(tensor, device) {
   */
 });
 
+testDevices(async function api_reduceMin(tensor, device) {
+  const a = tensor([
+    [9, 5, 7],
+    [6, 8, 4],
+  ]);
+  assertAllEqual(a.reduceMin([0]), [6, 5, 4]);
+  assertAllEqual(a.reduceMin([1]), [5, 4]);
+  assertAllEqual(a.reduceMin(), 4);
+  assertAllEqual(a.reduceMin([0], true), [[6, 5, 4]]);
+  assertAllEqual(a.reduceMin([1], true), [[5], [4]]);
+});
+
 testDevices(async function api_onesAndZerosLike(tensor, device) {
   const a = tensor([
     [9, 5, 7],

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -1303,3 +1303,8 @@ test(async function api_sin_cos_tan() {
   assertAllClose(grad(cos)(v), [0, a, 0]);
   assertAllClose(grad(tan)(v), [1, 2, 1]);
 });
+
+test(async function api_size() {
+  assert(api.range(20).size === 20);
+  assert(api.range(20).reshape([4, 5]).size === 20);
+});

--- a/src/dl.ts
+++ b/src/dl.ts
@@ -325,6 +325,12 @@ export class OpsDL implements types.BackendOps {
     return x.math.max(x, axes, keepDims);
   }
 
+  reduceMin(x: TensorDL, axes: number[], keepDims: boolean): TensorDL
+  {
+    ENV.setMath(x.math);
+    return x.math.min(x, axes, keepDims);
+  }
+
   equal(x: TensorDL, y: TensorDL): TensorDL {
     ENV.setMath(x.math);
     return x.math.equal(x, y);

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -458,6 +458,13 @@ defBW("reduceMax", (g, axes, keepDims) => {
   throw new Error("Not Implemented.");
 });
 
+export let reduceMin = defFW("reduceMin", (x, axes, keepDims) => {
+  return bo.reduceMin(x, axes, keepDims);
+});
+defBW("reduceMin", (g, axes, keepDims) => {
+  throw new Error("Not Implemented.");
+});
+
 export let equal = defFW("equal", (x, y) => bo.equal(x, y));
 defBW("equal", null, null); // Not differentiable.
 

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -505,6 +505,14 @@ export class Tensor implements types.Storage {
     return ops.reduceMax(this, axes, keepDims);
   }
 
+  /** Take the minimum value over the given axes.
+   * @param axes defaults to all.
+   */
+  reduceMin(axes?: number[], keepDims = false): Tensor {
+    if (!axes) axes = rangeJS(this.rank);
+    return ops.reduceMin(this, axes, keepDims);
+  }
+
   reduceLogSumExp(axes?: number[], keepDims = false): Tensor {
     if (!axes) axes = rangeJS(this.rank);
     return ops.reduceLogSumExp(this, axes, keepDims);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -169,6 +169,15 @@ export class Tensor implements types.Storage {
     return this.storage.shape;
   }
 
+  /** Returns the total number of elements
+   *
+   *    import { range } from "propel";
+   *    range(200).reshape([100, 2]).size
+   */
+  get size(): number {
+    return this.shape.reduce((a, b) => a * b);
+  }
+
   /** Returns the tensor as a printable string.
    *
    *    import * as pr from "propel";

--- a/src/tf.ts
+++ b/src/tf.ts
@@ -402,6 +402,17 @@ export class OpsTF implements types.BackendOps {
     ]);
   }
 
+  reduceMin(x: TensorTF, axes: number[], keepDims: boolean): TensorTF
+  {
+    // axesT is expected to be on CPU.
+    const axesT = int32Small(axes);
+    return execute0("Min", [x, axesT], [
+      ["T", binding.ATTR_TYPE, binding.getDType(x.handle)],
+      ["Tidx", binding.ATTR_TYPE, binding.TF_INT32],
+      ["keep_dims", binding.ATTR_BOOL, keepDims],
+    ]);
+  }
+
   equal(x: TensorTF, y: TensorTF): TensorTF {
     return execute1("Equal", [x, y]);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface BackendOps {
   reduceSum(x: Storage, axes: number[], keepDims: boolean): Storage;
   reduceMean(x: Storage, axes: number[], keepDims: boolean): Storage;
   reduceMax(x: Storage, axes: number[], keepDims: boolean): Storage;
+  reduceMin(x: Storage, axes: number[], keepDims: boolean): Storage;
   slice(x: Storage, begin: number[], size: number[]): Storage;
   gather(x: Storage, indices: Storage, axis: number): Storage;
   concat(axis: number, inputs: Storage[]): Storage;


### PR DESCRIPTION
and add tensor.size
I will need these APIs to implement NumPy's `array2string` (`tensor.toString()`)

https://github.com/numpy/numpy/blob/3629e3986333ecdf394924e53265e0d1061e928d/numpy/core/arrayprint.py#L1104-L1106