### PR TITLE
Some changes to how progress bars are handled

### DIFF
--- a/src/output_handler.ts
+++ b/src/output_handler.ts
@@ -37,7 +37,7 @@ const progressOutputHandlerMap = new Map<string, OutputHandler>();
 export class OutputHandlerDOM implements OutputHandler {
   // TODO colors should match those used by the syntax highlighting.
   private color = d3.scaleOrdinal(d3.schemeCategory10);
-  private progresses = new Map<string, Progress>();
+  private progressJobs = new Map<string, Progress>();
 
   constructor(private element: Element) {}
 
@@ -180,16 +180,16 @@ export class OutputHandlerDOM implements OutputHandler {
       // TODO: this isn't really correct - the progress bar might go backwards
       // when multiple parallel jobs are present and one completes before
       // the other.
-      this.progresses.delete(job);
+      this.progressJobs.delete(job);
       progressOutputHandlerMap.delete(job);
     } else {
-      this.progresses.set(job, progress);
+      this.progressJobs.set(job, progress);
     }
 
     const outputContainer = this.element.parentNode as HTMLElement;
     const progressBar = outputContainer.previousElementSibling as HTMLElement;
 
-    if (this.progresses.size === 0) {
+    if (this.progressJobs.size === 0) {
       // If there are no more downloads in progress, hide the progress bar.
       progressBar.style.width = "0"; // Prevent it from going backwards.
       progressBar.style.display = "none";
@@ -198,7 +198,7 @@ export class OutputHandlerDOM implements OutputHandler {
 
     let sumLoaded = 0;
     let sumTotal = 0;
-    for (const [_, {loaded, total}] of this.progresses) {
+    for (const [_, {loaded, total}] of this.progressJobs) {
       // Total may be null if the size of the download isn't known yet.
       if (total === null) {
         continue;

--- a/src/output_handler.ts
+++ b/src/output_handler.ts
@@ -16,9 +16,14 @@
 
 import * as d3 from "d3";
 import { createCanvas, Image } from "./im";
-import { Progress } from "./types";
 
 export type PlotData = Array<Array<{ x: number, y: number }>>;
+
+export interface Progress {
+  job: string;
+  loaded: number | null;
+  total: number | null;
+}
 
 export interface OutputHandler {
   imshow(image: Image): void;
@@ -27,11 +32,12 @@ export interface OutputHandler {
   downloadProgress(progress: Progress);
 }
 
-const progresses = {};
+const progressOutputHandlerMap = new Map<string, OutputHandler>();
 
 export class OutputHandlerDOM implements OutputHandler {
   // TODO colors should match those used by the syntax highlighting.
   private color = d3.scaleOrdinal(d3.schemeCategory10);
+  private progresses = new Map<string, Progress>();
 
   constructor(private element: Element) {}
 
@@ -156,30 +162,54 @@ export class OutputHandlerDOM implements OutputHandler {
   }
 
   downloadProgress(progress: Progress) {
+    const job = progress.job;
+
+    // Ensure that the progress handler jobs are always handled by the same
+    // output handler, even when the notebook guesses the cell wrong.
+    // TODO: this is really hacky and should not be the responsibility of the
+    // output handler at all.
+    const outputHandler = progressOutputHandlerMap.get(job);
+    if (outputHandler === undefined) {
+      progressOutputHandlerMap.set(job, this);
+    } else if (outputHandler !== this) {
+      return outputHandler.downloadProgress(progress);
+    }
+
+    if (progress.loaded === null) {
+      // When loaded equals null, this indicates that the job is done.
+      // TODO: this isn't really correct - the progress bar might go backwards
+      // when multiple parallel jobs are present and one completes before
+      // the other.
+      this.progresses.delete(job);
+      progressOutputHandlerMap.delete(job);
+    } else {
+      this.progresses.set(job, progress);
+    }
+
     const outputContainer = this.element.parentNode as HTMLElement;
     const progressBar = outputContainer.previousElementSibling as HTMLElement;
-    const {job, loaded, total} = progress;
-    progresses[job] = {
-      cell: this.element.id,
-      loaded,
-      total
-    };
-    if (loaded === total) {
-      delete progresses[job];
-    }
-    let totalLoaded = 0;
-    let totalTotal = 0;
-    for (const key in progresses) {
-      if (progresses[key].cell === this.element.id) {
-        totalLoaded += progresses[key].loaded;
-        totalTotal += progresses[key].total;
-      }
-    }
-    if (totalLoaded === totalTotal) {
+
+    if (this.progresses.size === 0) {
+      // If there are no more downloads in progress, hide the progress bar.
+      progressBar.style.width = "0"; // Prevent it from going backwards.
       progressBar.style.display = "none";
-    } else {
-      progressBar.style.display = "block";
-      progressBar.style.width = (totalLoaded / totalTotal * 100) + "%";
+      return;
     }
+
+    let sumLoaded = 0;
+    let sumTotal = 0;
+    for (const [_, {loaded, total}] of this.progresses) {
+      // Total may be null if the size of the download isn't known yet.
+      if (total === null) {
+        continue;
+      }
+      sumLoaded += loaded;
+      sumTotal += total;
+    }
+
+    // Avoid division by zero.
+    const percent = sumTotal > 0 ? sumLoaded / sumTotal * 100 : 0;
+    progressBar.style.display = "block";
+    progressBar.style.width = `${percent}%`;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,9 +141,3 @@ export interface TensorOpts {
 }
 
 export type Mode = "RGBA" | "RGB" | "L";
-
-export interface Progress {
-  job: string;
-  loaded: number;
-  total: number;
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,6 @@ import { OutputHandler } from "./output_handler";
 import { RegularArray } from "./types";
 
 const debug = false;
-export let attachedHandler: OutputHandler = null;
 
 // If you use the eval function indirectly, by invoking it via a reference
 // other than eval, as of ECMAScript 5 it works in the global scope rather than
@@ -134,9 +133,13 @@ export function objectsEqual(a: any, b: any): boolean {
 }
 
 const propelHosts = new Set(["", "127.0.0.1", "localhost", "propelml.org"]);
-export type FetchEncoding = "utf8" | "arraybuffer" | "buffer";
-// We return an ArrayBuffer on Web but a Buffer on Node.js
-export type BinaryData = Buffer | ArrayBuffer;
+
+export interface FetchEncodingMap {
+  "arraybuffer": ArrayBuffer;
+  "buffer": Buffer;
+  "utf8": string;
+}
+export type FetchEncoding = keyof FetchEncodingMap;
 
 // Takes either a fully qualified url or a path to a file in the propel
 // website directory. Examples
@@ -146,13 +149,13 @@ export type BinaryData = Buffer | ArrayBuffer;
 //
 // Propel files will use propelml.org if not being run in the project
 // directory.
-async function fetch2(p: string, encoding: FetchEncoding)
-                      : Promise<string | BinaryData> {
+async function fetch2<E extends FetchEncoding>(
+    p: string, encoding: E): Promise<FetchEncodingMap[E]> {
   // TODO The path hacks in this function are quite messy and need to be
   // cleaned up.
   if (IS_WEB) {
     const job = randomString();
-    const host = document.location.host.split(":")[0];
+    const host = document.location.hostname;
     if (propelHosts.has(host)) {
       p = p.replace("deps/", "/");
       p = p.replace(/^src\//, "/src/");
@@ -160,22 +163,22 @@ async function fetch2(p: string, encoding: FetchEncoding)
       p = p.replace("deps/", "http://propelml.org/");
       p = p.replace(/^src\//, "http://propelml.org/src/");
     }
-    const req = new XMLHttpRequest();
-    const onLoad = createResolvable();
-    req.onload = onLoad.resolve;
-    if (attachedHandler) {
-      req.onprogress = function({loaded, total}) {
-        attachedHandler.downloadProgress({ job, loaded, total });
-      };
+    try {
+      const req = new XMLHttpRequest();
+      const onLoad = createResolvable();
+      req.onload = onLoad.resolve;
+      req.onprogress = ev => downloadProgress(job, ev.loaded, ev.total);
+      req.open("GET", p, true);
+      req.responseType = encoding === "utf8" ? "text" : "arraybuffer";
+      if (encoding === "utf8") {
+        req.overrideMimeType("text/plain; charset=utf-8");
+      }
+      req.send();
+      await onLoad;
+      return req.response;
+    } finally {
+      downloadProgress(job, null, null);
     }
-    req.open("GET", p, true);
-    req.responseType = encoding === "utf8" ? "text" : "arraybuffer";
-    if (encoding === "utf8") {
-      req.overrideMimeType("text/plain; charset=utf-8");
-    }
-    req.send();
-    await onLoad;
-    return req.response;
   } else {
     if (p.match(/^http(s)*:\/\//)) {
       return fetchRemoteFile(p, encoding);
@@ -196,67 +199,96 @@ async function fetch2(p: string, encoding: FetchEncoding)
   }
 }
 
-async function fetchRemoteFile(url: string, encoding: FetchEncoding)
-                               : Promise<string | BinaryData> {
-  const promise = createResolvable();
-  const isBinary = encoding === "arraybuffer" || encoding === "buffer";
-  const schema = url.split(":")[0];
-  const http = nodeRequire(schema === "https" ? "https" : "http");
-  let body: string | Buffer[] = "";
-  if (isBinary) {
-    body = [];
-  }
-  http.get(url, (res) => {
-    const total = Number(res.headers["content-length"]);
-    const start = Date.now();
-    let loaded = 0;
-    res.setEncoding = isBinary ? null : "utf8";
-    res.on("data", (chunk) => {
-      if (isBinary) {
-        (body as Buffer[]).push(chunk);
-      } else {
-        body += chunk;
-      }
-      loaded += chunk.length;
-      if (Date.now() - start > 1000) {
-        const p = (loaded / total * 100).toFixed(2);
-        process.stdout.write(`${p}%\r`);
-      }
+async function fetchRemoteFile<E extends FetchEncoding>(
+    url: string, encoding: E): Promise<FetchEncodingMap[E]> {
+  const protocol = new URL(url).protocol;
+  const http = nodeRequire(protocol === "https:" ? "https" : "http");
+  const job = randomString();
+
+  downloadProgress(job, 0, null); // Start download job with unknown size.
+
+  const chunks: Buffer[] = [];
+
+  try {
+    const promise = createResolvable();
+    const req = http.get(url, res => {
+      const total = Number(res.headers["content-length"]);
+      let loaded = 0;
+      res.on("data", (chunk) => {
+        chunks.push(chunk);
+        loaded += chunk.length;
+        downloadProgress(job, loaded, total);
+      });
+      res.on("end", promise.resolve);
+      res.on("error", promise.reject);
     });
-    res.on("end", promise.resolve);
-  });
-  await promise;
-  if (isBinary) {
-    const b = Buffer.concat(body as Buffer[]);
-    if (encoding === "arraybuffer") {
-      return b.buffer as ArrayBuffer;
-    }
-    return b;
+    req.on("error", promise.reject);
+    await promise;
+
+  } finally {
+    downloadProgress(job, null, null); // End download job.
   }
-  return body as string;
+
+  const buffer = Buffer.concat(chunks);
+  if (encoding === "utf8") {
+    return buffer.toString("utf8");
+  } else {
+    return buffer;
+  }
 }
 
 export async function fetchArrayBuffer(path: string): Promise<ArrayBuffer> {
-  return await fetch2(path, "arraybuffer") as ArrayBuffer;
+  return await fetch2(path, "arraybuffer");
 }
 
 export async function fetchBuffer(path: string): Promise<Buffer> {
   if (IS_WEB) {
     throw new Error("`fetchBuffer` is not implemented to work on browser.");
   }
-  return await fetch2(path, "buffer") as Buffer;
+  return await fetch2(path, "buffer");
 }
 
 export async function fetchStr(path: string): Promise<string> {
-  return await fetch2(path, "utf8") as string;
+  return await fetch2(path, "utf8");
 }
 
-export function setOutputHandler(handler: OutputHandler) {
-  attachedHandler = handler;
+export let activeOutputHandler: OutputHandler | null = null;
+
+export function getOutputHandler(): OutputHandler | null {
+  return activeOutputHandler;
 }
 
-export function getOutputHandler(): OutputHandler {
-  return attachedHandler;
+export function setOutputHandler(handler: OutputHandler): void {
+  activeOutputHandler = handler;
+}
+
+let lastProgress = 0;
+
+export function downloadProgress(job: string, loaded: number | null,
+                                 total: number | null): void {
+  if (activeOutputHandler) {
+    activeOutputHandler.downloadProgress({ job, loaded, total });
+    return;
+  }
+
+  if (IS_NODE) {
+    if (loaded === null && total === null) {
+      // Write 7 spaces, so we can cover "100.00%".
+      process.stdout.write(" ".repeat(7) + " \r");
+    } else if (!total) {
+      // Don't divide by zero.
+      return;
+    }
+
+    const now = Date.now();
+    if (now - lastProgress > 500) {
+      // TODO: when multiple downloads are active, percentages currently
+      // write over one another.
+      const p = (loaded / total * 100).toFixed(2);
+      process.stdout.write(`${p}% \r`);
+      lastProgress = now;
+    }
+  }
 }
 
 export function randomString(): string {

--- a/website/main.scss
+++ b/website/main.scss
@@ -856,7 +856,6 @@ img.avatar {
   display: none;
   border-top: 1px solid $accentColor;
   margin-top: -$size0;
-  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 // Mobile first. No desktop related things above this line.

--- a/website/nb.ts
+++ b/website/nb.ts
@@ -32,6 +32,12 @@ import { RPC, WindowRPC } from "./rpc";
 const cellTable = new Map<number, Cell>(); // Maps id to Cell.
 let nextCellId = 1;
 
+export function resetNotebook() {
+  destroySandbox();
+  cellTable.clear();
+  nextCellId = 1;
+}
+
 const prerenderedOutputs = new Map<number, string>();
 
 export function registerPrerenderedOutput(output) {
@@ -125,7 +131,7 @@ function createSandbox(): void {
   sandboxRpc.start(rpcHandlers);
 }
 
-export function destroySandbox(): void {
+function destroySandbox(): void {
   if (!sandboxRpc) return;
 
   sandboxRpc.stop();
@@ -136,7 +142,7 @@ export function destroySandbox(): void {
   sandboxIframe = null;
 }
 
-function sandbox(): RPC {
+export function sandbox(): RPC {
   if (sandboxRpc === null) {
     createSandbox();
   }
@@ -556,9 +562,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
 
   async componentWillMount() {
     try {
-      const doc = this.props.nbId === "anonymous"
-        ? anonDoc
-        : await db.active.getDoc(this.props.nbId);
+      const doc = await (this.props.nbId === "anonymous"
+                         ? Promise.resolve(anonDoc)
+                         : db.active.getDoc(this.props.nbId));
       this.setState({ doc });
     } catch (e) {
       this.setState({ errorMsg: e.message });

--- a/website/sandbox.ts
+++ b/website/sandbox.ts
@@ -16,9 +16,8 @@
 import * as propel from "../src/api";
 import * as matplotlib from "../src/matplotlib";
 import * as mnist from "../src/mnist";
-import { setOutputHandler } from "../src/util";
 
-import { global, globalEval } from "../src/util";
+import { global, globalEval, setOutputHandler } from "../src/util";
 import { Transpiler } from "./nb_transpiler";
 import { RPC, WindowRPC } from "./rpc";
 
@@ -27,6 +26,7 @@ async function importModule(target) {
     matplotlib,
     mnist,
     propel,
+    test_internals
   }[target];
   if (m) {
     return m;

--- a/website/sandbox.ts
+++ b/website/sandbox.ts
@@ -16,6 +16,7 @@
 import * as propel from "../src/api";
 import * as matplotlib from "../src/matplotlib";
 import * as mnist from "../src/mnist";
+import * as test_internals from "./test_internals";
 
 import { global, globalEval, setOutputHandler } from "../src/util";
 import { Transpiler } from "./nb_transpiler";

--- a/website/test_internals.ts
+++ b/website/test_internals.ts
@@ -1,0 +1,1 @@
+export { downloadProgress } from "../src/util";


### PR DESCRIPTION
* Use byte length, not string length, when computing the number of bytes
  loaded so far.
* handle http.get() errors.
* Reduce the number of type assertions.
* Explicitly indicate the end of a download by calling
  downloadProgress(job, null, null).