### PR TITLE
Show interfaces in docs

### DIFF
--- a/tools/gendoc_test.ts
+++ b/tools/gendoc_test.ts
@@ -23,6 +23,7 @@ test(async function gendoc_smoke() {
   const names = docs.map(e => e.name);
   // Check that a few of the names are correct.
   assert(names.indexOf("Tensor") >= 0);
+  assert(names.indexOf("Params") >= 0);
   assert(names.indexOf("Tensor.add") >= 0);
   assert(names.indexOf("Tensor[Symbol.iterator]") >= 0);
 });


### PR DESCRIPTION
Params wasn’t showing up as gendoc.ts wasnt visiting interfaces (#469 ).

To show the interfaces in the docs I added `visitClass` in the [`ts.isInterfaceDeclaration` check](https://github.com/propelml/propel/compare/master...dangerdak:params-docs?expand=1#diff-324e575d0900c95fbd2bbfc469054499R188) but to do this I had to change type signatures for `visitClass`, `classElementName` and `visitProp` - not sure if this is a bad way to do things :grimacing:
I also added `ts.isMethodSignature` and `ts.isPropertySignature` checks to the `visitClass` function.
... Maybe there’s some nicer way to organise all this?

This caused some interfaces from `deps/` to show up (eg `Array` and `Promise`) so I filtered out nodes which contain the excludes from tsconfig.json in their declarations file paths. 

ConvOpts appears duplicated in the docs as it’s defined in both [src/types.ts](https://github.com/propelml/propel/blob/3aae62dcffda91500574a2f5b201fab9d6a75124/src/types.ts#L27) and [src/layers.ts](https://github.com/propelml/propel/blob/f5e25608af06b4abdfcb45cd8f1a229511e2ee7b/src/layers.ts#L47)

And I’m not sure why the [`MinimizeResult` interface](https://github.com/propelml/propel/blob/41c53c27cec0f8b97d98a728e340e7dfcc8dee20/src/optimizers.ts#L36) is showing up in the docs despite not being exported - is this expected?